### PR TITLE
Enabling Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,16 @@
 language: node_js
 node_js: [node]
+sudo: false
+
+# see https://github.com/kelektiv/node.bcrypt.js/blob/master/.travis.yml
+env:
+    - CXX=g++-4.8
+before_install:
+    - $CXX --version
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - g++-4.8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js: [node]
+


### PR DESCRIPTION
Please refer to https://docs.travis-ci.com/user/getting-started/ to enable Travis CI on the Github repository. This commit only contains the configuration file used to configure the build environment, but the repository must be configured by its owner before further pushes are scanned by Travis CI.

Please also refer to https://docs.travis-ci.com/user/status-images/ to add a build status icon to the README. The image link will be generated according to the Travis CI account to be created in the previous step described in the above reference.

This configuration file will run `npm test` using the latest `node` available in Travis CI containers (which should be 7.0.0 by now).